### PR TITLE
Training stability: Continue training even if a data batch was hit which causes OOM

### DIFF
--- a/valle/bin/trainer.py
+++ b/valle/bin/trainer.py
@@ -692,8 +692,19 @@ def train_one_epoch(
 
                 set_batch_count(model, params.batch_idx_train)
             except:  # noqa
+                # Save the broken batch
                 logging.warning(f"Hit a broken batch of training data. Cut ID: {batch['utt_id']} Text: {batch['text']} - Skipping...")
                 display_and_save_batch(batch, params=params)
+                # Clean up batch data from Memory and GPU
+                del batch["text_tokens"]
+                del batch["text_tokens_lens"]
+                del batch["audio_features"]
+                del batch["audio_features_lens"]
+                del batch
+                del loss
+                del loss_info
+                torch.cuda.empty_cache()
+                # Continue training
                 continue
 
             if params.average_period > 0:

--- a/valle/bin/trainer.py
+++ b/valle/bin/trainer.py
@@ -1102,6 +1102,10 @@ def scan_pessimistic_batches_for_oom(
     elif params.dtype in ["float16", "fp16"]:
         dtype = torch.float16
 
+    scaler = GradScaler(
+        enabled=(params.dtype in ["fp16", "float16"]), init_scale=1.0
+    )
+
     for criterion, cuts in batches.items():
         batch = train_dl.dataset[cuts]
         try:
@@ -1112,7 +1116,7 @@ def scan_pessimistic_batches_for_oom(
                     batch=batch,
                     is_training=True,
                 )
-            loss.backward()
+            scaler.scale(loss).backward()
             optimizer.zero_grad()
         except Exception as e:
             if "CUDA out of memory" in str(e):

--- a/valle/bin/trainer.py
+++ b/valle/bin/trainer.py
@@ -701,8 +701,11 @@ def train_one_epoch(
                 del batch["audio_features"]
                 del batch["audio_features_lens"]
                 del batch
-                del loss
-                del loss_info
+                try:
+                    del loss
+                    del loss_info
+                except UnboundLocalError:
+                    pass
                 torch.cuda.empty_cache()
                 # Continue training
                 continue

--- a/valle/bin/trainer.py
+++ b/valle/bin/trainer.py
@@ -692,8 +692,9 @@ def train_one_epoch(
 
                 set_batch_count(model, params.batch_idx_train)
             except:  # noqa
+                logging.warning(f"Hit a broken batch of training data. Cut ID: {batch['utt_id']} Text: {batch['text']} - Skipping...")
                 display_and_save_batch(batch, params=params)
-                raise
+                continue
 
             if params.average_period > 0:
                 if (


### PR DESCRIPTION
Following my Investigations mentioned in https://github.com/lifeiteng/vall-e/issues/110, I implemented some code which does the following in case a training batch causes an OOM error:

1. Print Metadata and text contents of the malicious batch to console
2. Deletes all references to the batch object from current training cycle
3. Deletes all references to loss output from current training cycle if it exists
4. Empty CUDA cache to free up stale memory
5. Continue training with the next batch

This should improve the training process in various aspects, such as:

- Easier identification of dataset content which is causing issues
- Training can still resume and eventually finish training the epoch in case there are just a few data elements casing issues.

Additionally, I discovered there is a Grad Scaling step missing in the Pre-Training OOM check, which explicitly was the code where the OOM Exception happened during training in my case. So I added thos as well