### PR TITLE
Fix Validation Step breaking Multi-GPU Training

### DIFF
--- a/valle/bin/trainer.py
+++ b/valle/bin/trainer.py
@@ -265,6 +265,13 @@ def get_parser():
         help="visualize model results in eval step.",
     )
 
+    parser.add_argument(
+        "--oom-check",
+        type=str2bool,
+        default=True,
+        help="perform OOM check on dataloader batches before starting training.",
+    )
+
     add_model_arguments(parser)
 
     return parser
@@ -1010,7 +1017,7 @@ def run(rank, world_size, args):
     )
     valid_dl = dataset.valid_dataloaders(valid_cuts)
 
-    if True:
+    if params.oom_check and params.start_epoch == 1:
         scan_pessimistic_batches_for_oom(
             model=model,
             train_dl=train_dl,

--- a/valle/bin/trainer.py
+++ b/valle/bin/trainer.py
@@ -559,6 +559,9 @@ def compute_validation_loss(
         assert loss.requires_grad is False
         tot_loss = tot_loss + loss_info
 
+    if world_size > 1:
+        tot_loss.reduce(loss.device)
+
     loss_value = tot_loss["loss"] / tot_loss["frames"]
     if loss_value < params.best_valid_loss:
         params.best_valid_epoch = params.cur_epoch
@@ -631,193 +634,192 @@ def train_one_epoch(
     elif params.dtype in ["float16", "fp16"]:
         dtype, enabled = torch.float16, True
 
-    model_context = model.join if isinstance(model, DDP) else nullcontext
-    with model_context():
-        batch_idx = 0
-        while True:
-            try:
-                batch = next(iter_dl)
-            except StopIteration:
-                logging.info("Reaches end of dataloader.")
-                break
+    batch_idx = 0
+    while True:
+        try:
+            batch = next(iter_dl)
+        except StopIteration:
+            logging.info("Reaches end of dataloader.")
+            break
 
-            batch_idx += 1
+        batch_idx += 1
 
-            params.batch_idx_train += 1
-            batch_size = len(batch["text"])
+        params.batch_idx_train += 1
+        batch_size = len(batch["text"])
 
-            try:
-                with torch.cuda.amp.autocast(dtype=dtype, enabled=enabled):
-                    _, loss, loss_info = compute_loss(
-                        params=params,
-                        model=model,
-                        batch=batch,
-                        is_training=True,
-                    )
-                # summary stats
-                tot_loss = (
-                    tot_loss * (1 - 1 / params.reset_interval)
-                ) + loss_info * (1 / params.reset_interval)
+        try:
+            with torch.cuda.amp.autocast(dtype=dtype, enabled=enabled):
+                _, loss, loss_info = compute_loss(
+                    params=params,
+                    model=model,
+                    batch=batch,
+                    is_training=True,
+                )
+            # summary stats
+            tot_loss = (
+                tot_loss * (1 - 1 / params.reset_interval)
+            ) + loss_info * (1 / params.reset_interval)
 
-                # NOTE: We use reduction==sum and loss is computed over utterances
-                # in the batch and there is no normalization to it so far.
+            # NOTE: We use reduction==sum and loss is computed over utterances
+            # in the batch and there is no normalization to it so far.
 
-                scaler.scale(loss).backward()
-                if params.batch_idx_train >= params.accumulate_grad_steps:
-                    if (
-                        params.batch_idx_train % params.accumulate_grad_steps
-                        == 0
-                    ):
-                        if params.optimizer_name not in ["ScaledAdam", "Eve"]:
-                            # Unscales the gradients of optimizer's assigned params in-place
-                            scaler.unscale_(optimizer)
-                            # Since the gradients of optimizer's assigned params are unscaled, clips as usual:
-                            torch.nn.utils.clip_grad_norm_(
-                                model.parameters(), 1.0
-                            )
-
-                        scaler.step(optimizer)
-                        scaler.update()
-                        optimizer.zero_grad()
-
-                        for k in range(params.accumulate_grad_steps):
-                            if isinstance(scheduler, Eden):
-                                scheduler.step_batch(params.batch_idx_train)
-                            else:
-                                scheduler.step()
-
-                set_batch_count(model, params.batch_idx_train)
-            except:  # noqa
-                display_and_save_batch(batch, params=params)
-                raise
-
-            if params.average_period > 0:
+            scaler.scale(loss).backward()
+            if params.batch_idx_train >= params.accumulate_grad_steps:
                 if (
-                    params.batch_idx_train > 0
-                    and params.batch_idx_train % params.average_period == 0
+                    params.batch_idx_train % params.accumulate_grad_steps
+                    == 0
                 ):
-                    # Perform Operation in rank 0
-                    if rank == 0:
-                        update_averaged_model(
-                            params=params,
-                            model_cur=model,
-                            model_avg=model_avg,
+                    if params.optimizer_name not in ["ScaledAdam", "Eve"]:
+                        # Unscales the gradients of optimizer's assigned params in-place
+                        scaler.unscale_(optimizer)
+                        # Since the gradients of optimizer's assigned params are unscaled, clips as usual:
+                        torch.nn.utils.clip_grad_norm_(
+                            model.parameters(), 1.0
                         )
-                    # Block other ranks until first process completes
-                    torch.distributed.barrier()
 
+                    scaler.step(optimizer)
+                    scaler.update()
+                    optimizer.zero_grad()
+
+                    for k in range(params.accumulate_grad_steps):
+                        if isinstance(scheduler, Eden):
+                            scheduler.step_batch(params.batch_idx_train)
+                        else:
+                            scheduler.step()
+
+            set_batch_count(model, params.batch_idx_train)
+        except:  # noqa
+            display_and_save_batch(batch, params=params)
+            raise
+
+        if params.average_period > 0:
             if (
                 params.batch_idx_train > 0
-                and params.batch_idx_train % params.save_every_n == 0
+                and params.batch_idx_train % params.average_period == 0
             ):
                 # Perform Operation in rank 0
                 if rank == 0:
-                    save_checkpoint_with_global_batch_idx(
-                        out_dir=params.exp_dir,
-                        global_batch_idx=params.batch_idx_train,
-                        model=model,
-                        model_avg=model_avg,
+                    update_averaged_model(
                         params=params,
-                        optimizer=optimizer,
-                        scheduler=scheduler,
-                        sampler=train_dl.sampler,
-                        scaler=scaler,
-                        rank=rank,
-                    )
-                    remove_checkpoints(
-                        out_dir=params.exp_dir,
-                        topk=params.keep_last_k,
-                        rank=rank,
+                        model_cur=model,
+                        model_avg=model_avg,
                     )
                 # Block other ranks until first process completes
                 torch.distributed.barrier()
 
-            if batch_idx % 100 == 0 and params.dtype in ["float16", "fp16"]:
-                # If the grad scale was less than 1, try increasing it.    The _growth_interval
-                # of the grad scaler is configurable, but we can't configure it to have different
-                # behavior depending on the current grad scale.
-                cur_grad_scale = scaler._scale.item()
-                if cur_grad_scale < 1.0 or (
-                    cur_grad_scale < 8.0 and batch_idx % 400 == 0
-                ):
-                    scaler.update(cur_grad_scale * 2.0)
+        if (
+            params.batch_idx_train > 0
+            and params.batch_idx_train % params.save_every_n == 0
+        ):
+            # Perform Operation in rank 0
+            if rank == 0:
+                save_checkpoint_with_global_batch_idx(
+                    out_dir=params.exp_dir,
+                    global_batch_idx=params.batch_idx_train,
+                    model=model,
+                    model_avg=model_avg,
+                    params=params,
+                    optimizer=optimizer,
+                    scheduler=scheduler,
+                    sampler=train_dl.sampler,
+                    scaler=scaler,
+                    rank=rank,
+                )
+                remove_checkpoints(
+                    out_dir=params.exp_dir,
+                    topk=params.keep_last_k,
+                    rank=rank,
+                )
+            # Block other ranks until first process completes
+            torch.distributed.barrier()
 
-                if cur_grad_scale < 0.01:
-                    logging.warning(f"Grad scale is small: {cur_grad_scale}")
-                if cur_grad_scale < 1.0e-05:
-                    raise RuntimeError(
-                        f"grad_scale is too small, exiting: {cur_grad_scale}"
-                    )
+        if batch_idx % 100 == 0 and params.dtype in ["float16", "fp16"]:
+            # If the grad scale was less than 1, try increasing it.    The _growth_interval
+            # of the grad scaler is configurable, but we can't configure it to have different
+            # behavior depending on the current grad scale.
+            cur_grad_scale = scaler._scale.item()
+            if cur_grad_scale < 1.0 or (
+                cur_grad_scale < 8.0 and batch_idx % 400 == 0
+            ):
+                scaler.update(cur_grad_scale * 2.0)
 
-            if batch_idx % params.log_interval == 0:
-                cur_lr = scheduler.get_last_lr()[0]
-                cur_grad_scale = (
-                    scaler._scale.item()
+            if cur_grad_scale < 0.01:
+                logging.warning(f"Grad scale is small: {cur_grad_scale}")
+            if cur_grad_scale < 1.0e-05:
+                raise RuntimeError(
+                    f"grad_scale is too small, exiting: {cur_grad_scale}"
+                )
+
+        if batch_idx % params.log_interval == 0:
+            cur_lr = scheduler.get_last_lr()[0]
+            cur_grad_scale = (
+                scaler._scale.item()
+                if params.dtype in ["float16", "fp16"]
+                else 1.0
+            )
+
+            logging.info(
+                f"Epoch {params.cur_epoch}, "
+                f"batch {batch_idx}, train_loss[{loss_info}], "
+                f"tot_loss[{tot_loss}], "
+                f"batch size: {batch_size}, "
+                f"lr: {cur_lr:.2e}"
+                + (
+                    f", grad_scale: {cur_grad_scale}"
                     if params.dtype in ["float16", "fp16"]
-                    else 1.0
+                    else ""
                 )
+            )
 
-                logging.info(
-                    f"Epoch {params.cur_epoch}, "
-                    f"batch {batch_idx}, train_loss[{loss_info}], "
-                    f"tot_loss[{tot_loss}], "
-                    f"batch size: {batch_size}, "
-                    f"lr: {cur_lr:.2e}"
-                    + (
-                        f", grad_scale: {cur_grad_scale}"
-                        if params.dtype in ["float16", "fp16"]
-                        else ""
-                    )
+            if tb_writer is not None:
+                tb_writer.add_scalar(
+                    "train/learning_rate", cur_lr, params.batch_idx_train
                 )
-
-                if tb_writer is not None:
+                loss_info.write_summary(
+                    tb_writer,
+                    "train/current_",
+                    params.batch_idx_train,
+                )
+                tot_loss.write_summary(
+                    tb_writer, "train/tot_", params.batch_idx_train
+                )
+                tot_loss.write_summary(
+                    tb_writer, "train/tot_", params.batch_idx_train
+                )
+                if params.dtype in ["float16", "fp16"]:
                     tb_writer.add_scalar(
-                        "train/learning_rate", cur_lr, params.batch_idx_train
-                    )
-                    loss_info.write_summary(
-                        tb_writer,
-                        "train/current_",
+                        "train/grad_scale",
+                        cur_grad_scale,
                         params.batch_idx_train,
                     )
-                    tot_loss.write_summary(
-                        tb_writer, "train/tot_", params.batch_idx_train
-                    )
-                    tot_loss.write_summary(
-                        tb_writer, "train/tot_", params.batch_idx_train
-                    )
-                    if params.dtype in ["float16", "fp16"]:
-                        tb_writer.add_scalar(
-                            "train/grad_scale",
-                            cur_grad_scale,
-                            params.batch_idx_train,
-                        )
 
-            if params.batch_idx_train % params.valid_interval == 0:
-                # Calculate validation loss in Rank 0
-                model.eval()
-                if rank == 0:
-                    logging.info("Computing validation loss")
-                    with torch.cuda.amp.autocast(dtype=dtype):
-                        valid_info = compute_validation_loss(
-                            params=params,
-                            model=model,
-                            valid_dl=valid_dl,
-                            world_size=world_size,
-                        )
-                    logging.info(
-                        f"Epoch {params.cur_epoch}, validation: {valid_info}"
-                    )
-                    logging.info(
-                        f"Maximum memory allocated so far is {torch.cuda.max_memory_allocated()//1000000}MB"
-                    )
+        if params.batch_idx_train % params.valid_interval == 0:
+            # Calculate validation loss in Rank 0
+            model.eval()
+            logging.info("Computing validation loss")
+            with torch.cuda.amp.autocast(dtype=dtype):
+                valid_info = compute_validation_loss(
+                    params=params,
+                    model=model,
+                    valid_dl=valid_dl,
+                    world_size=world_size,
+                )
+            logging.info(
+                f"Epoch {params.cur_epoch}, validation: {valid_info}"
+            )
+            logging.info(
+                f"Maximum memory allocated so far is {torch.cuda.max_memory_allocated()//1000000}MB"
+            )
 
-                    if tb_writer is not None:
-                        valid_info.write_summary(
-                            tb_writer, "train/valid_", params.batch_idx_train
-                        )
-                # Block other ranks until first process completes
-                torch.distributed.barrier()
-                model.train()
+            if tb_writer is not None:
+                valid_info.write_summary(
+                    tb_writer, "train/valid_", params.batch_idx_train
+                )
+            # Block other ranks until first process completes
+            logging.info("Waiting for validation loss to be computed")
+            torch.distributed.barrier()
+            logging.info("Resuming from wait state")
+            model.train()
 
     loss_value = tot_loss["loss"] / tot_loss["frames"]
     params.train_loss = loss_value

--- a/valle/bin/trainer.py
+++ b/valle/bin/trainer.py
@@ -1017,7 +1017,7 @@ def run(rank, world_size, args):
     )
     valid_dl = dataset.valid_dataloaders(valid_cuts)
 
-    if params.oom_check and params.start_epoch == 1:
+    if params.oom_check:
         scan_pessimistic_batches_for_oom(
             model=model,
             train_dl=train_dl,


### PR DESCRIPTION
I propose this PR to fix issues I encountered with Multi-GPU training.

Based on my own testing and research I found out:

- DDP Models keep themselves in sync between threads without using join context
- Join context implementation is not properly handled in the current implementation, according to docs (https://pytorch.org/tutorials/advanced/generic_join.html) this requires implementing the Joinable interface in the model class itself, plus additional hooks. However, the current code uses a `model.join` param which is actually a null pointer and therefore no different to nullcontext, plus does not keep the individual training threads in sync.
- If proper handling of the training threads is applied manually, and dataloaders support DDP approach with splitting of batches across world size (Which lhotse dataloaders support natively), the implementation of the Joinable interface is not required.

Therefore this PR applies the following changes:
- Removes broken join handling of training threads
- Explicit Synchronization of threads when performing the following operations in the main thread:
  - Saving of a model checkpoint
  - Updating the Averaged model
  - Computation of the validation loss (I found that there is no difference in validation loss result if performed by all threads at the same time, so it can be handled by one alone)
- Omitting the OOM check at training start if epoch > 1 or flag is set to omit it.

As intermediate Results, with these changes I was able to see the following results so far:
- No crashes / hangs on Validation Loss computation
- While training a whole epoch of 376k steps on a single GPU needed 28 hours to complete, I was able to train another epoch on 4 GPUs, which needed 95k steps and 20 hours to complete.