### PR TITLE
Set ddp_sampler drop_last=True

### DIFF
--- a/valle/bin/trainer.py
+++ b/valle/bin/trainer.py
@@ -565,7 +565,8 @@ def compute_validation_loss(
         )
         assert loss.requires_grad is False
         tot_loss = tot_loss + loss_info
-
+    if world_size > 1:
+        tot_loss.reduce(loss.device)
     loss_value = tot_loss["loss"] / tot_loss["frames"]
     if loss_value < params.best_valid_loss:
         params.best_valid_epoch = params.cur_epoch
@@ -708,10 +709,7 @@ def train_one_epoch(
                         model_cur=model,
                         model_avg=model_avg,
                     )
-                if world_size > 1:
-                    # Block other ranks until first process completes
-                    torch.distributed.barrier()
-
+             
         if (
             params.batch_idx_train > 0
             and params.batch_idx_train % params.save_every_n == 0
@@ -735,10 +733,7 @@ def train_one_epoch(
                     topk=params.keep_last_k,
                     rank=rank,
                 )
-            if world_size > 1:
-                # Block other ranks until first process completes
-                torch.distributed.barrier()
-
+         
         if batch_idx % 100 == 0 and params.dtype in ["float16", "fp16"]:
             # If the grad scale was less than 1, try increasing it.    The _growth_interval
             # of the grad scaler is configurable, but we can't configure it to have different
@@ -802,31 +797,26 @@ def train_one_epoch(
         if params.batch_idx_train % params.valid_interval == 0:
             # Calculate validation loss in Rank 0
             model.eval()
-            if rank == 0:
-                logging.info("Computing validation loss")
-                with torch.cuda.amp.autocast(dtype=dtype):
-                    valid_info = compute_validation_loss(
-                        params=params,
-                        model=model,
-                        valid_dl=valid_dl,
-                        world_size=world_size,
-                    )
-                logging.info(
-                    f"Epoch {params.cur_epoch}, validation: {valid_info}"
+            logging.info("Computing validation loss")
+            with torch.cuda.amp.autocast(dtype=dtype):
+                valid_info = compute_validation_loss(
+                    params=params,
+                    model=model,
+                    valid_dl=valid_dl,
+                    world_size=world_size,
                 )
-                logging.info(
-                    f"Maximum memory allocated so far is {torch.cuda.max_memory_allocated()//1000000}MB"
+            logging.info(
+                f"Epoch {params.cur_epoch}, validation: {valid_info}"
+            )
+            logging.info(
+                f"Maximum memory allocated so far is {torch.cuda.max_memory_allocated()//1000000}MB"
+            )
+
+            if tb_writer is not None:
+                valid_info.write_summary(
+                    tb_writer, "train/valid_", params.batch_idx_train
                 )
 
-                if tb_writer is not None:
-                    valid_info.write_summary(
-                        tb_writer, "train/valid_", params.batch_idx_train
-                    )
-            if world_size > 1:
-                # Block other ranks until first process completes
-                logging.info("Waiting for validation loss to be computed")
-                torch.distributed.barrier()
-                logging.info("Resuming from wait state")
             model.train()
 
     loss_value = tot_loss["loss"] / tot_loss["frames"]

--- a/valle/data/datamodule.py
+++ b/valle/data/datamodule.py
@@ -308,9 +308,9 @@ class TtsDataModule:
             train_sampler = DynamicBucketingSampler(
                 cuts_train,
                 max_duration=self.args.max_duration,
-                shuffle=True,
+                shuffle=self.args.shuffle,
                 num_buckets=self.args.num_buckets,
-                drop_last=self.args.drop_last,
+                drop_last=True,
             )
         else:
             logging.info(
@@ -363,7 +363,8 @@ class TtsDataModule:
         valid_sampler = DynamicBucketingSampler(
             cuts_valid,
             max_duration=self.args.max_duration,
-            shuffle=True,
+            shuffle=False,
+            drop_last=True,
         )
         logging.info("About to create dev dataloader")
         valid_dl = DataLoader(
@@ -390,7 +391,8 @@ class TtsDataModule:
         sampler = DynamicBucketingSampler(
             cuts,
             max_duration=self.args.max_duration,
-            shuffle=True,
+            shuffle=False,
+            drop_last=True,
         )
         logging.debug("About to create test dataloader")
         test_dl = DataLoader(

--- a/valle/data/datamodule.py
+++ b/valle/data/datamodule.py
@@ -308,7 +308,7 @@ class TtsDataModule:
             train_sampler = DynamicBucketingSampler(
                 cuts_train,
                 max_duration=self.args.max_duration,
-                shuffle=self.args.shuffle,
+                shuffle=True,
                 num_buckets=self.args.num_buckets,
                 drop_last=self.args.drop_last,
             )
@@ -363,7 +363,7 @@ class TtsDataModule:
         valid_sampler = DynamicBucketingSampler(
             cuts_valid,
             max_duration=self.args.max_duration,
-            shuffle=False,
+            shuffle=True,
         )
         logging.info("About to create dev dataloader")
         valid_dl = DataLoader(
@@ -390,7 +390,7 @@ class TtsDataModule:
         sampler = DynamicBucketingSampler(
             cuts,
             max_duration=self.args.max_duration,
-            shuffle=False,
+            shuffle=True,
         )
         logging.debug("About to create test dataloader")
         test_dl = DataLoader(


### PR DESCRIPTION
1，Set **DynamicBucketingSampler drop_last=True** to avoid different number of batches on multiple gpus. It is a bug in lhotse. The pr is trying to fix the problem.[Fix samplers dropping cuts when world_size > 1 ](https://github.com/lhotse-speech/lhotse/pull/695)
2, No need to use "torch.distributed.barrier()“.