### PR TITLE
fix bug: convert samples from list to tensors

### DIFF
--- a/valle/data/tokenizer.py
+++ b/valle/data/tokenizer.py
@@ -343,6 +343,7 @@ class AudioTokenExtractor(FeatureExtractor):
                 )
                 for wav in samples
             ]
+            samples = torch.stack(samples, 0) # convert samples from list to tensor
         # Extract discrete codes from EnCodec
         with torch.no_grad():
             encoded_frames = self.tokenizer.encode(samples.detach().to(device))


### PR DESCRIPTION
convert samples from list to tensors, or the next sentence samples.detach() will have error.